### PR TITLE
fix(annotations): swap OnSlashCommand params so name comes before group

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ class StatsCommand {
     suspend fun userStats(ctx: SlashCommandContext, user: User?) { ... }
 
     // /stats server info
-    @OnSlashCommand(group = "server", name = "info")
+    @OnSlashCommand(name = "info", group = "server")
     suspend fun serverInfo(ctx: SlashCommandContext) { ... }
 
     // /stats server members
-    @OnSlashCommand(group = "server", name = "members")
+    @OnSlashCommand(name = "members", group = "server")
     suspend fun serverMembers(ctx: SlashCommandContext) { ... }
 }
 ```
@@ -318,10 +318,10 @@ class ColorCommand {
 }
 ```
 
-For subcommand handlers, set `group` and `name` on `@OnAutoComplete` to match the handler:
+For subcommand handlers, set `name` and `group` on `@OnAutoComplete` to match the handler:
 
 ```kotlin
-@OnAutoComplete(group = "clips", name = "top", option = "channel")
+@OnAutoComplete(name = "top", group = "clips", option = "channel")
 suspend fun completeChannel(ctx: AutoCompleteContext, channel: String) { ... }
 ```
 
@@ -372,11 +372,11 @@ Declare required Discord permissions at class level (all handlers) or function l
 @ApplicationCommand(name = "setup")
 class SetupCommand {
 
-    @OnSlashCommand(group = "greetings", name = "preview")
+    @OnSlashCommand(name = "preview", group = "greetings")
     @Permissions([Permission.MESSAGE_EMBED_LINKS], PermissionTarget.BOT)  // bot needs embed links
     suspend fun greetingsPreview(ctx: GuildSlashCommandContext) { ... }
 
-    @OnSlashCommand(group = "greetings", name = "set")
+    @OnSlashCommand(name = "set", group = "greetings")
     @Permissions([Permission.MANAGE_GUILD])                               // user needs manage guild
     suspend fun greetingsSet(ctx: GuildSlashCommandContext, channel: TextChannel) { ... }
 }

--- a/slash-annotations/src/main/kotlin/io/github/blad3mak3r/slash/annotations/OnAutoComplete.kt
+++ b/slash-annotations/src/main/kotlin/io/github/blad3mak3r/slash/annotations/OnAutoComplete.kt
@@ -3,14 +3,14 @@ package io.github.blad3mak3r.slash.annotations
 /**
  * Marks a suspend function as the autocomplete handler for a slash command option.
  *
- * @param group Optional subcommand-group name (must match the parent [OnSlashCommand]).
  * @param name  Optional subcommand name (must match the parent [OnSlashCommand]).
+ * @param group Optional subcommand-group name (must match the parent [OnSlashCommand]).
  * @param option The option name this handler provides completions for.
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.SOURCE)
 annotation class OnAutoComplete(
-    val group: String = "",
     val name: String = "",
+    val group: String = "",
     val option: String
 )

--- a/slash-annotations/src/main/kotlin/io/github/blad3mak3r/slash/annotations/OnSlashCommand.kt
+++ b/slash-annotations/src/main/kotlin/io/github/blad3mak3r/slash/annotations/OnSlashCommand.kt
@@ -3,16 +3,16 @@ package io.github.blad3mak3r.slash.annotations
 /**
  * Marks a suspend function as the handler for a [CommandType.SLASH] command (or subcommand).
  *
- * @param group Optional subcommand-group name.
  * @param name  Optional subcommand name.
+ * @param group Optional subcommand-group name.
  * @param target The [InteractionTarget] this handler accepts.
  * @param supportDetached Whether the command supports detached guild messages.
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.SOURCE)
 annotation class OnSlashCommand(
-    val group: String = "",
     val name: String = "",
+    val group: String = "",
     val target: InteractionTarget = InteractionTarget.GUILD,
     val supportDetached: Boolean = false
 )


### PR DESCRIPTION
## Summary

- Swaps `name` and `group` parameter order in `@OnSlashCommand` so that `name` is the first (positional) parameter.
- Updates KDoc to match the new order.

## Motivation

Previously, commands without a group had to write `name = ""` explicitly when using positional arguments. With `name` first, `@OnSlashCommand("mysubcommand")` works directly without needing to specify `group = ""`.

## Test plan

- [ ] Verify existing usages compile correctly (all use named parameters, no positional breakage).
- [ ] Confirm `@OnSlashCommand("subcommand")` resolves to `name` as expected.